### PR TITLE
Remove no longer usable default tfbackend

### DIFF
--- a/infra/networks/default.s3.tfbackend
+++ b/infra/networks/default.s3.tfbackend
@@ -1,4 +1,0 @@
-bucket         = "platform-flask-806908981117-us-east-1-tf"
-key            = "infra/networks/default.tfstate"
-dynamodb_table = "platform-flask-806908981117-us-east-1-tf-state-locks"
-region         = "us-east-1"


### PR DESCRIPTION
**Note: This is the same issue as in https://github.com/navapbc/platform-test-nextjs/pull/83. Reproduced below for reference.**

---

## Ticket

N/A

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Remove `/infra/networks/default.s3.tfbackend`

## Context for reviewers

<!-- Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. -->

I noticed that there were 2 backends in `/infra/networks`:

- dev.s3.tfbackend (expected)
- default.s3.tfbackend

I wasn't sure what `default.s3.tfbackend` did, so I did a careful `init` and `plan`:

- `terraform -chdir="infra/networks" init -input=false -reconfigure -backend-config="default.s3.tfbackend"`
- `terraform -chdir="infra/networks" plan -var="network_name=default"`

The `terraform plan` resulted in this error:

```
Plan: 29 to add, 0 to change, 3 to destroy.
╷
│ Error: Invalid index
│ 
│   on main.tf line 8, in locals:
│    8:   network_config = module.project_config.network_configs[var.network_name]
│     ├────────────────
│     │ module.project_config.network_configs is object with 3 attributes
│     │ var.network_name is "default"
│ 
│ The given key does not identify an element in this collection value.
```

This makes sense as the network name I passed in isn't in `/infra/project-config/networks.tf`. I checked the AWS Console (I checked in `us-east-1`, `us-east-2`, `us-west-1`, `us-west-2`) and did not see a VPC that corresponded to it. I suspect this is vestigial from before we had a custom VPC.

## Testing

<!-- Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://getkap.co/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox. -->

<img width="600" alt="CleanShot 2024-05-03 at 11 59 36@2x" src="https://github.com/navapbc/platform-test-flask/assets/67701/4fb4a34c-dc91-4d63-8ef7-444d7721c6f7">
